### PR TITLE
Scaling and shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,18 @@ will create the folders for you. You will end up with:
 Usage
 ====
 
-`$ python android-res-resize.py --folder ~/MyProject/res/drawables-xhdpi` resize all
+`$ chmod +x android-res-resize.py` Makes the script runnable.
+
+`$./android-res-resize.py --folder ~/MyProject/res/drawables-xhdpi` resize all
 found images in xhdpi folder.
 
-`$ python android-res-resize.py --file ~/MyProjects/res/drawables-xhdpi/my_image.png`
+`$ ./android-res-resize.py --file ~/MyProjects/res/drawables-xhdpi/my_image.png`
 resize specific image only.
 
-`$ python android-res-resize.py --prod` automatically find xhdpi folder and execute
+`$ ./android-res-resize.py --prod` automatically find xhdpi folder and execute
 as with --folder option.
 
-Hint: all output can be silenced by adding the `--silence` option.
+Hint: all output can be silenced by adding the `--silence` option. You can also exclude a scale using the `--exclude-scale [ldpi|mdpi|hdpi]` option.
 
 Feedback & Improvements
 ====

--- a/android-res-resize.py
+++ b/android-res-resize.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
         from os.path import join, dirname, abspath, exists
         folderPath = join(dirname(abspath(__file__)),"res/drawable-xhdpi")
         if exists(folderPath):
-            resizer.resizeAllInFolder(args.folderPath)
+            resizer.resizeAllInFolder(folderPath)
             resizer.log("Done.")
         else:
             print "Couldn't find res/drawable-xhdpi from your current location."

--- a/android-res-resize.py
+++ b/android-res-resize.py
@@ -27,6 +27,8 @@ class AndroidResResize:
 
     SILENCE = False
 
+    EXCLUDE_SCALE = ""
+
     """
     Set verbosity level of application.
     Supports verbose or silent
@@ -34,6 +36,13 @@ class AndroidResResize:
     def setVerbosity(self, silence):
         if silence:
             self.SILENCE = silence;
+
+    """
+    Set a scale to exclude from processing.
+    Supports ldpi, mdpi, hdpi
+    """
+    def setExcludeScale(self, scale):
+        self.EXCLUDE_SCALE = scale;
 
     """
     Print to console if script hasn't been silenced
@@ -74,6 +83,9 @@ class AndroidResResize:
         if fileExtension in self.ACCEPTED_EXTENSIONS:
 
             for scale in self.SCALES:
+                if scale == self.EXCLUDE_SCALE:
+                    continue
+
                 self.log("Processing (" + scale + "): " + filePath)
 
                 # get scale value
@@ -115,11 +127,13 @@ if __name__ == "__main__":
     argParser.add_argument("--prod", default=None, action="store_true", dest="prod", help="Looks for res/drawable-xhdpi subfolder and resize all the images in that folder.")
     argParser.add_argument("--folder", default=None, dest="folderPath", help="Resizes all images in provided folder path.")
     argParser.add_argument("--file", default=None, dest="filePath", help="Resizes individual file provided by folder path.")
+    argParser.add_argument("--exclude-scale", default=None, dest="scale", help="Excludes a specific scale, such as ldpi")
     argParser.add_argument("--silence", default=False, dest="option_silence", help="Silences all output.")
     args = argParser.parse_args()
 
     resizer = AndroidResResize()
     resizer.setVerbosity(args.option_silence)
+    resizer.setExcludeScale(args.scale)
 
     if args.prod:
         from os.path import join, dirname, abspath, exists

--- a/android-res-resize.py
+++ b/android-res-resize.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 """
     Version 0.3


### PR DESCRIPTION
Fixed a critical bug in --prod argument. Was referencing wrong variable.
Added shebang for the script. Only need to set the script to runnable (chmod +x) and it can be run as normal. Saw a different shebang in one of the other pull requests but this one is better as it is environment independent.

```
./android-res-resize.py
```

Also added a simple scaling option, doesn't get more simple than that.

Refers to #6 and #7
